### PR TITLE
gcvis/main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,7 +47,13 @@ func main() {
 	}
 
 	parser := NewParser(pipeRead)
-	gcvisGraph := NewGraph(strings.Join(flag.Args(), " "), GCVIS_TMPL)
+
+	title := strings.Join(flag.Args(), " ")
+	if len(title) == 0 {
+		title = fmt.Sprintf("%s:%s", *iface, *port)
+	}
+
+	gcvisGraph := NewGraph(title, GCVIS_TMPL)
 	server := NewHttpServer(*iface, *port, &gcvisGraph)
 
 	go parser.Run()


### PR DESCRIPTION
Issue: When using pipe call scheme (not a subcommand one), title of the page was not being set properly (it was rendered as `gcvis -`)

Here I suggest setting it to `iface:port` in such cases (eg. for `localhost:6060` the page title would render as `gcvis - localhost:6060`)
